### PR TITLE
Add static allowOverrides

### DIFF
--- a/DIKit/Sources/Container/DependencyContainer+Register.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Register.swift
@@ -42,7 +42,7 @@ extension DependencyContainer {
     public func register(_ component: ComponentProtocol) {
         precondition(!bootstrapped, "After boostrap no more components can be registered.")
         threadSafe {
-            guard self.componentStack[component.identifier] == nil else {
+            guard DependencyContainer.allowOverrides || self.componentStack[component.identifier] == nil else {
                 fatalError("A component can only be registered once.")
             }
             self.componentStack[component.identifier] = component

--- a/DIKit/Sources/Container/DependencyContainer.swift
+++ b/DIKit/Sources/Container/DependencyContainer.swift
@@ -30,6 +30,11 @@ public final class DependencyContainer {
         return root
     }
 
+    // MARK: - Configuration
+    /// A global flag to allow duplicate registrations of components.
+    /// Should only be used in a debug context, like in a mock setup for Previews. Should not be used in a release build.
+    public static var allowOverrides: Bool = false
+
     // MARK: - Public methods
     /// Derives a `DependencyContainer` from multiple sub containers.
     ///
@@ -40,7 +45,11 @@ public final class DependencyContainer {
     public static func derive(from containers: DependencyContainer...) -> DependencyContainer {
         return DependencyContainer(containers.reduce(into: ComponentStack()) { (result, container) in
             result.merge(container.componentStack) { (old, new) -> ComponentProtocol in
-                fatalError("A `Component` was declared at least twice `\(old)` -> `\(new)`.")
+                if DependencyContainer.allowOverrides {
+                    new
+                } else {
+                    fatalError("A `Component` was declared at least twice `\(old)` -> `\(new)`.")
+                }
             }
         })
     }
@@ -54,7 +63,11 @@ public final class DependencyContainer {
     public static func derive(from containers: [DependencyContainer]) -> DependencyContainer {
         return DependencyContainer(containers.reduce(into: ComponentStack()) { (result, container) in
             result.merge(container.componentStack) { (old, new) -> ComponentProtocol in
-                fatalError("A `Component` was declared at least twice `\(old)` -> `\(new)`.")
+                if DependencyContainer.allowOverrides {
+                    new
+                } else {
+                    fatalError("A `Component` was declared at least twice `\(old)` -> `\(new)`.")
+                }
             }
         })
     }

--- a/DIKit/Tests/DependencyContainerTests.swift
+++ b/DIKit/Tests/DependencyContainerTests.swift
@@ -163,4 +163,34 @@ class DependencyContainerTests: XCTestCase {
         XCTAssertTrue(componentAinstanceA !== taggedComponentAinstanceA)
         XCTAssertTrue(componentAinstanceA !== taggedComponentAinstanceB)
     }
+
+    func testDependencyOverride() {
+        protocol TestComponentProtocol {
+            var id: Int { get }
+        }
+        struct ComponentA: TestComponentProtocol {
+            let id: Int
+        }
+
+        // Setting allowOverrides to false should run into a fatalError, which sadly is not that easy to test.
+        DependencyContainer.allowOverrides = true
+        let dependencyContainer =
+                modules(makeChildren: {
+                    module {
+                        single { ComponentA(id: 1) }
+                        single { ComponentA(id: 2) }
+                        single { ComponentA(id: 3) as TestComponentProtocol }
+                    }
+                    module {
+                        single { ComponentA(id: 4) as TestComponentProtocol }
+                    }
+                })
+
+        let componentA: ComponentA = dependencyContainer.resolve()
+        let componentB: TestComponentProtocol = dependencyContainer.resolve()
+        XCTAssertNotNil(componentA)
+        XCTAssertNotNil(componentB)
+        XCTAssertEqual(componentA.id, 2)
+        XCTAssertEqual(componentB.id, 4)
+    }
 }


### PR DESCRIPTION
Adds a static configuration 'allowOverrides: Bool', with default false. 
When set to true, it allows to merge containers with duplicate component definitions.

- Has no impact on current API.
- Unit tests only cover allowOverrides = true 